### PR TITLE
docs: add MIT license badge and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Python Template
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A modern Python project template with automated development workflows and quality tools.
 
 ## Features
@@ -41,7 +43,3 @@ make clean    # Remove build artifacts
 ## Documentation
 
 For detailed development setup, project structure, and contribution guidelines, see [DEVELOPMENT.md](DEVELOPMENT.md).
-
-## License
-
-This project is licensed under the MIT License. See the LICENSE file for details.


### PR DESCRIPTION
## Summary
- Add MIT license badge to README header for quick visibility
- Remove redundant license section at bottom since badge provides link