### PR TITLE
feat: add mechanical color label schema and documentation

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,90 @@
+# Mechanical Color Label Schema
+
+# Types
+- name: "⚙️ T-Feat"
+  color: "0E8A16"
+  description: "New feature or capability"
+
+- name: "🐞 T-Fix"
+  color: "D73A4A"
+  description: "Bug fix"
+
+- name: "🧱 T-Refactor"
+  color: "0075CA"
+  description: "Code improvement without behavior change"
+
+- name: "🧰 T-Chore"
+  color: "FEF2C0"
+  description: "Maintenance task"
+
+- name: "📘 T-Docs"
+  color: "1D76DB"
+  description: "Documentation update"
+
+# Status
+- name: "⬜ S-Todo"
+  color: "E4E4E4"
+  description: "Not started"
+
+- name: "🟨 S-Doing"
+  color: "FBCA04"
+  description: "In progress"
+
+- name: "🟪 S-Review"
+  color: "A371F7"
+  description: "Ready for review"
+
+- name: "🟩 S-Done"
+  color: "0E8A16"
+  description: "Completed"
+
+# Priority
+- name: "🔴 P-0"
+  color: "B60205"
+  description: "Critical priority"
+
+- name: "🟠 P-1"
+  color: "D93F0B"
+  description: "High priority"
+
+- name: "🟡 P-2"
+  color: "FBCA04"
+  description: "Medium priority"
+
+- name: "🟢 P-3"
+  color: "0E8A16"
+  description: "Low priority"
+
+# Area
+- name: "🧩 A-Tooling"
+  color: "D4C5F9"
+  description: "Ruff, pytest, mypy, nox"
+
+- name: "🧩 A-Dependencies"
+  color: "C5DEF5"
+  description: "Package management"
+
+- name: "🧩 A-Docker"
+  color: "BFD4F2"
+  description: "Containers, DevContainer"
+
+- name: "🧩 A-Testing"
+  color: "F9D0C4"
+  description: "Test infrastructure"
+
+# Effort
+- name: "📏 E-S"
+  color: "C2E0C6"
+  description: "Small effort (< 1 day)"
+
+- name: "📏 E-M"
+  color: "FEF2C0"
+  description: "Medium effort (1-3 days)"
+
+- name: "📏 E-L"
+  color: "F7C6C7"
+  description: "Large effort (3-5 days)"
+
+- name: "📏 E-XL"
+  color: "E99695"
+  description: "Extra large effort (> 5 days)"

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,0 +1,101 @@
+# Label Schema
+
+This project uses the **Mechanical Color** label schema for organizing issues and pull requests. Labels are categorized into five dimensions:
+
+## Label Categories
+
+### 🏷️ Type (Required)
+
+Identifies the nature of the work:
+
+- **⚙️ T-Feat** - New feature or capability
+- **🐞 T-Fix** - Bug fix
+- **🧱 T-Refactor** - Code improvement without behavior change
+- **🧰 T-Chore** - Maintenance task (dependencies, tooling, configuration)
+- **📘 T-Docs** - Documentation update
+
+### 📊 Status (Required)
+
+Tracks progress through the workflow:
+
+- **⬜ S-Todo** - Not started
+- **🟨 S-Doing** - In progress
+- **🟪 S-Review** - Ready for review
+- **🟩 S-Done** - Completed
+
+### 🎯 Priority (Required)
+
+Indicates urgency and importance:
+
+- **🔴 P-0** - Critical priority (blocks release, security issues)
+- **🟠 P-1** - High priority (needed soon)
+- **🟡 P-2** - Medium priority (planned work)
+- **🟢 P-3** - Low priority (nice to have)
+
+### 🧩 Area (Optional)
+
+Identifies the part of the codebase affected:
+
+- **🧩 A-Tooling** - Ruff, pytest, mypy, nox
+- **🧩 A-Dependencies** - Package management
+- **🧩 A-Docker** - Containers, DevContainer
+- **🧩 A-Testing** - Test infrastructure
+
+### 📏 Effort (Optional)
+
+Estimates work required:
+
+- **📏 E-S** - Small effort (< 1 day)
+- **📏 E-M** - Medium effort (1-3 days)
+- **📏 E-L** - Large effort (3-5 days)
+- **📏 E-XL** - Extra large effort (> 5 days)
+
+## Usage Guidelines
+
+### Creating Issues
+
+Every issue should have at minimum:
+1. One **Type** label
+2. One **Status** label (typically ⬜ S-Todo)
+3. One **Priority** label
+
+Add **Area** and **Effort** labels when known.
+
+**Example:** A new feature for Docker configuration that's high priority and medium effort:
+```
+⚙️ T-Feat | 🟨 S-Doing | 🟠 P-1 | 🧩 A-Docker | 📏 E-M
+```
+
+### Updating Status
+
+As work progresses, update the status label:
+- Starting work: Change ⬜ S-Todo → 🟨 S-Doing
+- Ready for review: Change 🟨 S-Doing → 🟪 S-Review
+- Merged/completed: Change 🟪 S-Review → 🟩 S-Done
+
+### Pull Requests
+
+PRs inherit labels from their related issues. Add the same Type, Area, and Priority labels to maintain consistency.
+
+## Managing Labels
+
+Labels are defined in `.github/labels.yml`. Use the GitHub CLI to create labels:
+
+```bash
+gh label create "⚙️ T-Feat" --color "0E8A16" --description "New feature or capability" -f
+gh label create "🐞 T-Fix" --color "D73A4A" --description "Bug fix" -f
+# ... continue for all labels in .github/labels.yml
+```
+
+Or use the GitHub web interface to manually create labels based on the schema defined in `.github/labels.yml`.
+
+## Visual Board Organization
+
+Labels are designed for visual project boards:
+- **Types** use distinct emojis for quick scanning
+- **Status** uses color progression (white → yellow → purple → green)
+- **Priority** uses traffic light colors (red → orange → yellow → green)
+- **Areas** all use 🧩 for visual consistency
+- **Effort** all use 📏 for visual consistency
+
+This makes it easy to filter and organize issues on GitHub Projects boards.


### PR DESCRIPTION
## Summary
- Add Mechanical Color label schema for standardized issue/PR organization  
- Add comprehensive documentation for label usage

## Label Schema
- **Types:** ⚙️ T-Feat, 🐞 T-Fix, 🧱 T-Refactor, 🧰 T-Chore, 📘 T-Docs
- **Status:** ⬜ S-Todo, 🟨 S-Doing, 🟪 S-Review, 🟩 S-Done
- **Priority:** 🔴 P-0, 🟠 P-1, 🟡 P-2, 🟢 P-3
- **Area:** 🧩 A-Tooling, 🧩 A-Dependencies, 🧩 A-Docker, 🧩 A-Testing
- **Effort:** 📏 E-S, 📏 E-M, 📏 E-L, 📏 E-XL

Labels can be created manually using GitHub CLI or the web interface based on the schema in `.github/labels.yml`.

Full documentation available in `docs/labels.md`.

Closes #25